### PR TITLE
convert_lengthとテストコード

### DIFF
--- a/convert_length/convert_length.rb
+++ b/convert_length/convert_length.rb
@@ -1,0 +1,5 @@
+UNITS = { m: 1.0, ft: 3.28, in: 39.37 }
+def convert_length(length, from: :m, to: :in)
+  units = { :m => 1.0, :ft => 3.28, :in => 39.37 }
+  (length / UNITS[from] * UNITS[to]).round(2)
+end

--- a/convert_length/convert_length_test.rb
+++ b/convert_length/convert_length_test.rb
@@ -1,0 +1,10 @@
+require "minitest/autorun"
+require "~/ruby_introduction/convert_length/convert_length"
+
+class ConvertLengthTest < MiniTest::Test
+  def test_convert_length
+    assert_equal 39.37, convert_length(1, from: :m, to: :in)
+    assert_equal 0.38, convert_length(15, from: :in, to: :m)
+    assert_equal 10670.73, convert_length(35000, from: :ft, to: :m)
+  end
+end


### PR DESCRIPTION
**p156~161 長さの単位変換プログラムを作成する**
・メートル（m）、フィート（ft）、インチ（in）の単位を相互に変換する。
・第1引数に変換元の長さ（数値）、第2引数に変換元の単位、第3引数に変換後の単位を指定する。
・メソッドの戻り値は変換後の長さ（数値）とする。端数が出る場合は小数第3位で四捨五入する。

ハッシュの基礎を再度復習することができた。
実際にコードにすることで、文字列ではなくシンボルを使うと良いタイミング、それにより変更しなければならない点等をより具体的に知ることができた。