### PR TITLE
convert_hash_syntaxとテストコード

### DIFF
--- a/convert_hash_syntax/convert_hash_syntax.rb
+++ b/convert_hash_syntax/convert_hash_syntax.rb
@@ -1,0 +1,5 @@
+def convert_hash_syntax(old_syntax)
+  old_syntax.gsub(/:(\w+) *=> */,'\1: ')
+end
+
+  

--- a/convert_hash_syntax/convert_hash_syntax_test.rb
+++ b/convert_hash_syntax/convert_hash_syntax_test.rb
@@ -1,0 +1,22 @@
+require "minitest/autorun"
+require "~/ruby_introduction/convert_hash_syntax/convert_hash_syntax"
+
+class ConvertHashSyntaxTest < MiniTest::Test
+  def test_convert_hash_syntax
+    old_syntax = <<~TEXT
+      {
+        :name => 'Alice',
+        :age=>20,
+        :gender => :female
+      }
+    TEXT
+    expected = <<~TEXT
+      {
+        name: 'Alice',
+        age: 20,
+        gender: :female
+      }
+    TEXT
+    assert_equal expected, convert_hash_syntax(old_syntax)
+  end
+end


### PR DESCRIPTION
**p191~196 Rubyのハッシュ記法を変換する**
Rubyのハッシュ記法を文字列として受け取り、シンボルがキーであるものについては`=>`を使わない新しい記法に修正して返す。

正規表現の必要性、その働きを学ぶことができた。
学習する前は暗号にしか見えなかった、正規表現が学習後はそれぞれがどういう意味なのか理解することが出来る様になった。
またこの例題を解いている最中、シングルクォートとダブルクォートで挙動が違うことがあるという事を実際に体験することができた。（ダブルクォートでは目的の動作にならなかった）