### PR TITLE
word_synthとeffectおよびそれらのテストコード

### DIFF
--- a/word_synth/effects.rb
+++ b/word_synth/effects.rb
@@ -1,0 +1,13 @@
+module Effects
+  def self.reverse
+    ->(words) { words.split(" ").map(&:reverse).join(" ") }
+  end
+
+  def self.echo(rate)
+    ->(words) { words.chars.map { |c| c == " " ? c : c * rate }.join }
+  end
+
+  def self.loud(level)
+    ->(words) { words.split(" ").map { |word| word.upcase + "!" * level }.join(" ") }
+  end
+end

--- a/word_synth/effects.rb
+++ b/word_synth/effects.rb
@@ -4,7 +4,7 @@ module Effects
   end
 
   def self.echo(rate)
-    ->(words) { words.split("").map { |c| c == " " ? c : c * rate }.join }
+    ->(words) { words.split(" ").map { |word| word.chars.map { |c| c * rate }.join }.join(" ") } 
   end
 
   def self.loud(level)

--- a/word_synth/effects.rb
+++ b/word_synth/effects.rb
@@ -4,7 +4,7 @@ module Effects
   end
 
   def self.echo(rate)
-    ->(words) { words.chars.map { |c| c == " " ? c : c * rate }.join }
+    ->(words) { words.split("").map { |c| c == " " ? c : c * rate }.join }
   end
 
   def self.loud(level)

--- a/word_synth/effects_test.rb
+++ b/word_synth/effects_test.rb
@@ -1,0 +1,25 @@
+require "minitest/autorun"
+require_relative "effects"
+
+class EffectsTest < MiniTest::Test
+  def test_reverse
+    effect = Effects.reverse
+    assert_equal "ybuR si !nuf", effect.call("Ruby is fun!")
+  end
+
+  def test_echo
+    effect = Effects.echo(2)
+    assert_equal "RRuubbyy iiss ffuunn!!", effect.call("Ruby is fun!")
+
+    effect = Effects.echo(3)
+    assert_equal "RRRuuubbbyyy iiisss fffuuunnn!!!", effect.call("Ruby is fun!")
+  end
+
+  def test_loud
+    effect = Effects.loud(2)
+    assert_equal "RUBY!! IS!! FUN!!!", effect.call("Ruby is fun!")
+
+    effect = Effects.loud(3)
+    assert_equal "RUBY!!! IS!!! FUN!!!!", effect.call("Ruby is fun!")
+  end
+end

--- a/word_synth/word_synth.rb
+++ b/word_synth/word_synth.rb
@@ -1,0 +1,13 @@
+class WordSynth
+  def initialize
+    @effects = []
+  end
+
+  def add_effect(effect)
+    @effects << effect
+  end
+
+  def play(original_words)
+    @effects.inject(original_words) { |words, effect| effect.call(words) }
+  end
+end

--- a/word_synth/word_synth_test.rb
+++ b/word_synth/word_synth_test.rb
@@ -1,0 +1,25 @@
+require "minitest/autorun"
+require_relative "word_synth"
+require_relative "effects"
+
+
+class WordSynthTest < MiniTest::Test
+  def test_play_without_effects
+    synth = WordSynth.new
+    assert_equal "Ruby is fun!", synth.play("Ruby is fun!")
+  end
+
+  def test_play_with_reverse
+    synth = WordSynth.new
+    synth.add_effect(Effects.reverse)
+    assert_equal "ybuR si !nuf", synth.play("Ruby is fun!")
+  end
+
+  def test_play_with_echo
+    synth = WordSynth.new
+    synth.add_effect(Effects.echo(2))
+    synth.add_effect(Effects.loud(3))
+    synth.add_effect(Effects.reverse)
+    assert_equal "!!!YYBBUURR !!!SSII !!!!!NNUUFF", synth.play("Ruby is fun!")
+  end
+end


### PR DESCRIPTION
**p378~387　ワードシンセサイザーの作成**
入力された英文に対して、加工を行うプログラム
加工エフェクトは3つ
・リバース：各単語を逆順にする
・エコー：指定された回数だけ各文字を繰り返す
・ラウド：全て大文字に変換し、各単語の末尾に指定された回数だけ"!"をつける

一連の処理をオブジェクトとして扱う事に対して、違和感があったが、ある程度その感覚をつかむ事ができた。
また、ブロックを引数にする事により、他のメソッドに引き渡せる様になるというのはとても便利だと感じた。
Procオブジェクトを作成する際に用いる、Proc.newとラムダそれぞれの特徴（引数の個数に対する柔軟性）と使い所がわかった。